### PR TITLE
Not validating cloud config yaml if cloud config flag is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ testCoverage
 concourse-bosh-lite.yml
 concourse-cloudconfig.yml
 cloud-config.yml
+.idea/

--- a/deployment/concourse/concourse.go
+++ b/deployment/concourse/concourse.go
@@ -59,7 +59,7 @@ func (d *Deployment) doCloudConfigValidation() (err error) {
 	var data []byte
 	if data, err = ioutil.ReadFile(d.CloudConfigYml); err == nil {
 		c := &enaml.CloudConfigManifest{}
-		if err := yaml.Unmarshal(data, c); err != nil {
+		if err = yaml.Unmarshal(data, c); err != nil {
 			return err
 		}
 
@@ -118,8 +118,10 @@ func (d *Deployment) Initialize() (err error) {
 	if d.CloudConfig && "" == d.CloudConfigYml {
 		err = fmt.Errorf("Must provide cloudConfigYml location")
 		return
-	} else if err = d.doCloudConfigValidation(); err != nil {
-		return
+	} else if d.CloudConfig {
+		if err = d.doCloudConfigValidation(); err != nil {
+			return
+		}
 	}
 
 	var web *enaml.InstanceGroup

--- a/deployment/concourse/concourse_test.go
+++ b/deployment/concourse/concourse_test.go
@@ -1,9 +1,9 @@
 package concourse_test
 
 import (
+	. "github.com/enaml-ops/enaml-concourse-sample/deployment/concourse"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/enaml-ops/enaml-concourse-sample/deployment/concourse"
 )
 
 var _ = Describe("Concourse Deployment", func() {
@@ -241,6 +241,18 @@ var _ = Describe("Concourse Deployment", func() {
 			It("then we should error and prompt the user for a better pass", func() {
 				err := deployment.Initialize()
 				Ω(err).ShouldNot(BeNil())
+			})
+		})
+	})
+
+	Describe("Given a new deployment", func() {
+		Context("when calling Initialize with Cloud Config set to false ", func() {
+
+			deployment.ConcoursePassword = "test"
+			deployment.CloudConfig = false
+			It("then the Cloud Config validation should not be performed", func() {
+				err := deployment.Initialize()
+				Ω(err).Should(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
Added in a small logic to not validate cloud config yaml if the flag is false, today it appears to be validating it and failing if the flag is set to false. 